### PR TITLE
Add annotations for collector deployment

### DIFF
--- a/base/deployment.yaml
+++ b/base/deployment.yaml
@@ -2,6 +2,11 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: &app otel-collector
+  annotations:
+    "app.uw.systems/description": "OpenTelemetry collector"
+    "app.uw.systems/tier": "tier_3"
+    "app.uw.systems/tags.oss": "true"
+    "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/opentelemetry-manifests"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This deployment just wraps the third-party image
`otel/opentelemetry-collector-contrib:0.75.0` so annotating this with `tags.oss=true`. The other tags are just the required basics.

Ticket: DENA-87