### PR TITLE
Fix link to OpenTelemtry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Overall](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fapp.opslevel.com%2Fapi%2Fservice_level%2Fmag0hvpki88PEiM5mCYyWTo49M6sOFLitqAZ-cJw9y0)](https://app.opslevel.com/services/otel-collector/maturity-report)
 
-Namespace that runs [OpenTelemetry](opentelemetry.io/) Collector to inject,
-process & export traces for teams at UW.
+Namespace that runs [OpenTelemetry](https://opentelemetry.io/) Collector to
+inject, process & export traces for teams at UW.
 
 ![Design](./otel.svg)
 


### PR DESCRIPTION
Without a protocol the rendered markdown would link to (the non-existent)
<https://github.com/utilitywarehouse/opentelemetry-manifests/blob/main/opentelemetry.io>