### PR TITLE
Allow 1m for looking up trace by id

### DIFF
--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -49,7 +49,7 @@ query_frontend:
 querier:
   max_concurrent_queries: 500
   trace_by_id:
-    query_timeout: 30s
+    query_timeout: 60s
 
   frontend_worker:
     frontend_address: tempo-query-frontend-discovery:9095


### PR DESCRIPTION
Seems 30s is not currently enough for some queries.
Example: [query](https://grafana.prod.aws.uw.systems/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D,%22queryType%22:%22traceql%22,%22limit%22:20,%22filters%22:%5B%7B%22id%22:%224baf53c8%22,%22operator%22:%22%3D%22,%22scope%22:%22span%22%7D%5D,%22query%22:%22d72cdfe39b870b8edde3531780f7b1fd%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D)