### PR TITLE
Fix resources definition for query-frontend 

### DIFF
--- a/tempo/base/query-frontend/deployment.yaml
+++ b/tempo/base/query-frontend/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               cpu: 100m
               memory: 500Mi
             limits:
-              cpu: 1m
+              cpu: "1"
               memory: 2Gi
           readinessProbe:
             httpGet:

--- a/tempo/base/query-frontend/deployment.yaml
+++ b/tempo/base/query-frontend/deployment.yaml
@@ -34,10 +34,10 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 500Mi
             limits:
-              cpu: "1"
+              cpu: "2"
               memory: 2Gi
           readinessProbe:
             httpGet:

--- a/tempo/base/query-frontend/deployment.yaml
+++ b/tempo/base/query-frontend/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 0m
+              cpu: 100m
               memory: 500Mi
             limits:
               cpu: 1m


### PR DESCRIPTION
We were using `1m`  for limit, thus the CPU was getting throttled a lot.
After this, the query speed got 4x better
