### PR TITLE
DENA-249: Retrieve bigger traces

### DIFF
--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -5,7 +5,7 @@ server:
   # 20 mb- above max_bytes_per_trace, as querying the trace data from frontend
   # can return values bigger than that.
   grpc_server_max_recv_msg_size: 20_000_000
-  grpc_server_max_send_msg_size: 20_000_000
+  grpc_server_max_send_msg_size: 50_000_000
 
 memberlist:
   abort_if_cluster_join_fails: false
@@ -55,7 +55,7 @@ querier:
     frontend_address: tempo-query-frontend-discovery:9095
     grpc_client_config:
       max_recv_msg_size: 20_000_000
-      max_send_msg_size: 20_000_000
+      max_send_msg_size: 50_000_000
 
 distributor:
   receivers:

--- a/tempo/base/querier/deployment.yaml
+++ b/tempo/base/querier/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               memory: 1Gi
             limits:
               cpu: 1
-              memory: 4Gi
+              memory: 5Gi
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
- Updated GRPC send msg size to retrieve bigger traces
- Increased max memory for queriers to allow big traces to be retrieved.
