### PR TITLE
Add requests for metrics generator

### DIFF
--- a/tempo/base/metrics-generator/deployment.yaml
+++ b/tempo/base/metrics-generator/deployment.yaml
@@ -43,10 +43,10 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 0
+              cpu: 100m
               memory: 500Mi
             limits:
-              cpu: 1
+              cpu: 1500m
               memory: 2Gi
           readinessProbe:
             httpGet:

--- a/tempo/base/metrics-generator/deployment.yaml
+++ b/tempo/base/metrics-generator/deployment.yaml
@@ -43,7 +43,7 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 100m
+              cpu: 200m
               memory: 500Mi
             limits:
               cpu: 1500m


### PR DESCRIPTION
The CPU was being throttled this morning: https://utilitywarehouse.slack.com/archives/C050DMK37QT/p1695106216467179

Regular usage is around 150m https://grafana.prod.aws.uw.systems/d/faeKgjeMk/kubernetes-pod-usage-vs-resource-app?orgId=1&var-namespace=otel&var-app=tempo-metrics-generator&var-pod=All&var-app_kubernetes_io_name=All&from=1695097737468&to=1695107700035