### PR TITLE
Lower CPU requests on tempo ingester pods

### DIFF
--- a/tempo/base/ingester/statefulset.yaml
+++ b/tempo/base/ingester/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 500m
+              cpu: 20m
               memory: 2Gi
             limits:
               cpu: 2


### PR DESCRIPTION
This is importing some changes made from downstream `kustomization`s. We noticed these pods using a very small amount of CPU, even when in a high traffic setting (i.e. during times of very high memory usage).