### PR TITLE
Further lower ingester CPU requests

### DIFF
--- a/tempo/base/ingester/statefulset.yaml
+++ b/tempo/base/ingester/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 20m
+              cpu: 0m
               memory: 2Gi
             limits:
               cpu: 2


### PR DESCRIPTION
Follow up from ffc209244ad2fbcef9d5dfa65b82c7e8822f0d41, we wanted to
distinguish between:

* 0m meaning: we've seen it use a small, insignificant amount of CPU, vs.
* 20m meaning: we have measured it, and it idles at 0.02 CPU shares,
  we've made no such measurements