### PR TITLE
Tempo v2.3.0

### DIFF
--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -119,17 +119,23 @@ compactor:
     kvstore:
       store: memberlist
 
-# todo: change overrides syntax https://github.com/grafana/tempo/blob/a2b5c608022ba1467e317960e0b5bed1e9ff5ec4/CHANGELOG.md?plain=1#L32-L55
 overrides:
-  # 5 mb
-  # Spans added to blocks over that limit will be dropped
-  # thus, it doesn't really guarantee there will be no bigger traces,
-  # but it limits them enough to allow querying any trace.
-  max_bytes_per_trace: 5_000_000
-  max_traces_per_user: 0
-  metrics_generator_forwarder_queue_size: 500
-  metrics_generator_processor_service_graphs_enable_client_server_prefix: true
-  metrics_generator_forwarder_workers: 5
-  metrics_generator_processors:
-    - service-graphs
-    - span-metrics
+  defaults:
+    global:
+      # 5mb
+      # Spans added to blocks over that limit will be dropped
+      # thus, it doesn't really guarantee there will be no bigger traces,
+      # but it limits them enough to allow querying any trace.
+      max_bytes_per_trace: 5_000_000
+    ingestion:
+      max_traces_per_user: 0
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics
+      forwarder:
+        queue_size: 10_000
+        workers: 20
+      processor:
+        service_graphs:
+          enable_client_server_prefix: true

--- a/tempo/base/kustomization.yaml
+++ b/tempo/base/kustomization.yaml
@@ -6,7 +6,7 @@ configMapGenerator:
     files:
       - tempo.yaml=config.yaml
   - name: tempo-config-overlay
-    # Env from this configmap are injected to Tempo deploys/ sts in order to be used in tempo.yaml.
+    # Env from this configmap are injected to Tempo deploys/sts in order to be used in tempo.yaml.
     # Currently, there is no way to template configmap contents using Kustomize.
     literals:
       - S3_BUCKET=example-s3-bucket
@@ -26,4 +26,4 @@ resources:
 images:
   - name: tempo
     newName: grafana/tempo
-    newTag: 2.2.4
+    newTag: 2.3.0


### PR DESCRIPTION
v2.3.0 release with basic change to support new (clearer) override config.

Release does not yet make use of new features from vParquet3.