### PR TITLE
ingester: decrease the max_block_duration to 5m from 15m and max_block_bytes to 100 MB from 500 Mb

### DIFF
--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -72,7 +72,9 @@ distributor:
           reload_interval: 1h
 
 ingester:
-  max_block_duration: 15m
+  max_block_duration: 5m
+  # 100 MB for a block in ingester
+  max_block_bytes: 100_000_000
   lifecycler:
     ring:
       replication_factor: 3


### PR DESCRIPTION
We had a spike yesterday.
This should make the ingesters cope better with the load.

For full context and readings see: https://utilitywarehouse.slack.com/archives/C02QB672AKH/p1700194889166819 