### PR TITLE
Tempo v2.4.0 refinement

### DIFF
--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -89,7 +89,6 @@ storage:
       path: /var/tempo/wal
 
     block:
-      version: vParquet3
       # https://grafana.com/docs/tempo/latest/operations/dedicated_columns/
       #
       # Dedicated attribute columns are limited to 10 span attributes and 10 resource attributes with string values.

--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -1,5 +1,6 @@
 # use curl http://localhost:3200/status/config after connecting to any of components to get current config
 http_api_prefix: ""
+stream_over_http_enabled: true
 server:
   http_listen_port: 3200
   # 20 mb- above max_bytes_per_trace, as querying the trace data from frontend

--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -162,8 +162,6 @@ cache:
     - bloom
     - frontend-search
     - parquet-footer
-    - parquet-column-idx
-    - parquet-offset-idx
     - parquet-page
     memcached:
       consistent_hash: true


### PR DESCRIPTION
Cleans up a few config items after the v2.4 release notes highlighted a few points.
Commits explain the why.

Hopefully this should be the last step before promoting the release to production. 