### PR TITLE
OTel collector v0.95.0

### DIFF
--- a/otel-collector/deployment.yaml
+++ b/otel-collector/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: *app
-          image: otel/opentelemetry-collector-contrib:0.92.0
+          image: otel/opentelemetry-collector-contrib:0.95.0
           args:
             - "--config=/conf/otel-collector.yaml"
           resources:


### PR DESCRIPTION
- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.93.0
- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.94.0
- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.95.0

Key change for us in `v0.93.0`:

```
kafkareceiver: The Kafka receiver now exports some partition-specific metrics per-partition, with a partition tag (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30177)
The following metrics now render per partition:
kafka_receiver_messages
kafka_receiver_current_offset
kafka_receiver_offset_lag
```

Apart from that keeps things up to date, brings in bug fixes & improves OTTL ahead of us looking at tail-sampling