### PR TITLE
PLA2-100: tempo: read from dedicated otel kafka cluster

### DIFF
--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -63,9 +63,9 @@ distributor:
     kafka:
       protocol_version: 2.6.0
       brokers:
-        - kafka-shared-0.kafka-shared-headless.pubsub.svc.cluster.aws:9092
-        - kafka-shared-1.kafka-shared-headless.pubsub.svc.cluster.aws:9092
-        - kafka-shared-2.kafka-shared-headless.pubsub.svc.cluster.aws:9092
+        - kafka-bitnami-0.kafka-bitnami-headless.otel.svc.cluster.aws:9092
+        - kafka-bitnami-1.kafka-bitnami-headless.otel.svc.cluster.aws:9092
+        - kafka-bitnami-2.kafka-bitnami-headless.otel.svc.cluster.aws:9092
       group_id: processor-tempo
       topic: "otel.otlp_spans"
       client_id: processor-tempo


### PR DESCRIPTION
This is in preparation for the actual switch.

Since we don't need older data in kafka, the plan is:
1. Switch otel collector to the new otel dedicated kafka cluster
2. Wait for the Tempo lag to clear on the old cluster
3. Switch Tempo to the new otel dedicated kafka cluster