### PR TITLE
DENA-908: tempo: add horizontal pod autoscaler to distributor and ingester

### DIFF
--- a/tempo/base/distributor/deployment.yaml
+++ b/tempo/base/distributor/deployment.yaml
@@ -11,7 +11,6 @@ metadata:
     "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/opentelemetry-manifests"
     "app.uw.systems/repos.tempo": "https://github.com/grafana/tempo"
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: *app
@@ -44,10 +43,10 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 0
-              memory: 1Gi
+              cpu: "1500m"
+              memory: 2Gi
             limits:
-              cpu: 2
+              cpu: "2"
               memory: 4Gi
           readinessProbe:
             httpGet:

--- a/tempo/base/distributor/hpa.yaml
+++ b/tempo/base/distributor/hpa.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: &app tempo-distributor
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: *app
+  minReplicas: 3
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 95
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 95

--- a/tempo/base/distributor/kustomization.yaml
+++ b/tempo/base/distributor/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - kafka-certificate.yaml
+  - hpa.yaml

--- a/tempo/base/ingester/hpa.yaml
+++ b/tempo/base/ingester/hpa.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: &app tempo-ingester
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: *app
+  minReplicas: 3
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 95
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 95

--- a/tempo/base/ingester/kustomization.yaml
+++ b/tempo/base/ingester/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - statefulset.yaml
+  - hpa.yaml

--- a/tempo/base/ingester/statefulset.yaml
+++ b/tempo/base/ingester/statefulset.yaml
@@ -20,7 +20,6 @@ metadata:
     "app.uw.systems/repos.tempo": "https://github.com/grafana/tempo"
 spec:
   podManagementPolicy: Parallel
-  replicas: 10
   selector:
     matchLabels:
       app: *app
@@ -71,8 +70,8 @@ spec:
                 name: tempo-config-overlay
           resources:
             requests:
-              cpu: 0m
-              memory: 2Gi
+              cpu: "1500m"
+              memory: 3Gi
             limits:
               cpu: 2
               memory: 6Gi


### PR DESCRIPTION
Also adjusted a bit the default requests and limits for them. 
It is especially important to have non 0 requests specified, now that HPA is in place, as that's the value that HPA checks against