### PR TITLE
Stop using ballast

### DIFF
--- a/tempo/base/compactor/deployment.yaml
+++ b/tempo/base/compactor/deployment.yaml
@@ -34,7 +34,6 @@ spec:
           args:
             - -target=compactor
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
             - -config.expand-env=true
             - -shutdown-delay=15s
           env:

--- a/tempo/base/distributor/deployment.yaml
+++ b/tempo/base/distributor/deployment.yaml
@@ -35,9 +35,11 @@ spec:
           args:
             - -target=distributor
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
             - -config.expand-env=true
             - -shutdown-delay=15s
+          env:
+            - name: GOMEMLIMIT
+              value: "3500MiB"
           envFrom:
             - configMapRef:
                 name: tempo-config-overlay

--- a/tempo/base/ingester/statefulset.yaml
+++ b/tempo/base/ingester/statefulset.yaml
@@ -62,9 +62,11 @@ spec:
           args:
             - -target=ingester
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
             - -config.expand-env=true
             - -shutdown-delay=15s
+          env:
+            - name: GOMEMLIMIT
+              value: "5500MiB"
           envFrom:
             - configMapRef:
                 name: tempo-config-overlay

--- a/tempo/base/metrics-generator/statefulset.yaml
+++ b/tempo/base/metrics-generator/statefulset.yaml
@@ -53,8 +53,10 @@ spec:
           args:
             - -target=metrics-generator
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
             - -config.expand-env=true
+          env:
+            - name: GOMEMLIMIT
+              value: "1500MiB"
           envFrom:
             - configMapRef:
                 name: tempo-config-overlay

--- a/tempo/base/querier/deployment.yaml
+++ b/tempo/base/querier/deployment.yaml
@@ -36,9 +36,11 @@ spec:
           args:
             - -target=querier
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
             - -config.expand-env=true
             - -shutdown-delay=15s
+          env:
+            - name: GOMEMLIMIT
+              value: "4500MiB"
           envFrom:
             - configMapRef:
                 name: tempo-config-overlay

--- a/tempo/base/query-frontend/deployment.yaml
+++ b/tempo/base/query-frontend/deployment.yaml
@@ -33,9 +33,11 @@ spec:
           args:
             - -target=query-frontend
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
             - -config.expand-env=true
             - -shutdown-delay=15s
+          env:
+            - name: GOMEMLIMIT
+              value: "1500MiB"
           envFrom:
             - configMapRef:
                 name: tempo-config-overlay


### PR DESCRIPTION
GOMEMLIMIT is now the recommended way since Go 1.20