### PR TITLE
Import basic manifests for `web-collector`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ flowchart LR
     Pod[
         **pod**
         Running our applications with OpenTelmetry instrumentation
-    ] -- "quickly offload traces" --> OTEL
+    ] -- "quickly offload traces" --> Collector
+    PubClients[
+        **Public Clients**
+        Public clients, like web or mobile applocations,
+        running our applications with OpenTelmetry instrumentation
+    ] --> CollectorWeb
 
     subgraph OTEL[OpenTelemetry stack]
     direction LR
@@ -22,9 +27,15 @@ flowchart LR
             **collector**
             additional handling like retries, batching
         ]
+        CollectorWeb["
+            **web collector (optional)**
+            second collector, meant specificially for traffic from public apps
+        "]
+        CollectorWeb-->Collector
     end OTEL
 
-    OTEL -- "via Collector's Exporter" --> Kafka -- "via Tempo's Distributor" --> Grafana
+    Collector -- "via Collector's Exporter" --> Kafka
+    Kafka -- "via Tempo's Distributor" --> Grafana
 
     subgraph Grafana[Grafana stack]
     Tempo["

--- a/otel-web-collector/README.md
+++ b/otel-web-collector/README.md
@@ -1,0 +1,5 @@
+# OpenTelemetry Web Collector
+
+A separated instance of the [OpenTelemetry
+Collector](https://opentelemetry.io/docs/collector/) that is meant to accept
+traces from *public* HTTP clients, for example: web and mobile clients.

--- a/otel-web-collector/deployment.yaml
+++ b/otel-web-collector/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: &app otel-collector-web
+spec:
+  selector:
+    matchLabels:
+      app: *app
+  maxUnavailable: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &app otel-collector-web
+  annotations:
+    "app.uw.systems/description": "OpenTelemetry collector for client-side telemetry"
+    "app.uw.systems/tier": "tier_3"
+    "app.uw.systems/tags.oss": "true"
+spec:
+  selector:
+    matchLabels:
+      app: *app
+  replicas: 2
+  minReadySeconds: 5
+  progressDeadlineSeconds: 120
+  template:
+    metadata:
+      name: *app
+      labels:
+        app: *app
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8888"
+        prometheus.io/path: /metrics
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: *app
+          image: otel/opentelemetry-collector-contrib:0.107.0
+          args:
+            - "--config=/conf/otel-collector.yaml"
+          env:
+            - name: GOMEMLIMIT
+              value: "200MiB"
+          resources:
+            requests:
+              cpu: 0
+              memory: 200Mi
+            limits:
+              cpu: 1
+              memory: 300Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          ports:
+            - name: otlp-http-json
+              containerPort: 4318
+            - name: ext-zpages
+              containerPort: 55679
+            - name: collector-prom
+              containerPort: 8888
+            - name: prom
+              containerPort: 8889
+          volumeMounts:
+            - name: otel-collector-web-config-vol
+              mountPath: /conf
+      volumes:
+        - name: otel-collector-web-config-vol
+          configMap:
+            name: otel-collector-web
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - *app

--- a/otel-web-collector/example_config.yaml
+++ b/otel-web-collector/example_config.yaml
@@ -1,0 +1,36 @@
+# example config, not actually used
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:7777"
+        cors:
+          allowed_origins:
+            - https://*.uw.co.uk
+          max_age: 7200
+
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+  zpages:
+    endpoint: "0.0.0.0:55679"
+
+exporters:
+  otlp:
+    # forward traces onto another collector
+    endpoint: "dns:///otel-collector:4317"
+    balancer_name: round_robin
+    sending_queue:
+      enabled: true
+      queue_size: 30000
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 1800s
+
+service:
+  extensions: [health_check, zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [otlp]

--- a/otel-web-collector/kustomization.yaml
+++ b/otel-web-collector/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml


### PR DESCRIPTION
Importing the config from what's defined in our running manifests. This is so we can have more of the moving parts for our OTEL stack defined in this repo.

Ticket: DENA-950