### PR TITLE
Move Tempo metric backend up from manifests

### DIFF
--- a/tempo/base/metrics-backend/config/prometheus.yaml
+++ b/tempo/base/metrics-backend/config/prometheus.yaml
@@ -1,0 +1,3 @@
+storage:
+  exemplars:
+    max_exemplars: 100000

--- a/tempo/base/metrics-backend/disruption-budget.yaml
+++ b/tempo/base/metrics-backend/disruption-budget.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: &app prometheus
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: *app

--- a/tempo/base/metrics-backend/kustomization.yaml
+++ b/tempo/base/metrics-backend/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - name: prometheus
+    files:
+      - prometheus.yml=config/prometheus.yaml
+
+resources:
+  - statefulset.yaml
+  - services.yaml
+  - disruption-budget.yaml
+
+images:
+  - name: prometheus
+    newName: prom/prometheus
+    newTag: v2.39.1

--- a/tempo/base/metrics-backend/services.yaml
+++ b/tempo/base/metrics-backend/services.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  ports:
+    - name: prometheus
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app: prometheus
+---
+# Allows remote_write_api to push into each Prometheus instance for redundency
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-push
+  annotations:
+    # Scrapes metrics about Prometheus instance, not the metrics we push in.
+    # Those metrics are scraped using federation on the shared infra Thanos instance.
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9090"
+    prometheus.io/scrape: "true"
+spec:
+  ports:
+    - name: prometheus
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  clusterIP: None
+  selector:
+    app: prometheus

--- a/tempo/base/metrics-backend/statefulset.yaml
+++ b/tempo/base/metrics-backend/statefulset.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: &app prometheus
+  annotations:
+    "app.uw.systems/description": "Stores high-cardinality metrics for Tempo metrics-generator"
+    "app.uw.systems/tier": "tier_3"
+    "app.uw.systems/tags.oss": "true"
+    "app.uw.systems/repos.prometheus": "https://github.com/prometheus/prometheus"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 2
+  selector:
+    matchLabels:
+      app: *app
+  serviceName: *app
+  template:
+    metadata:
+      labels:
+        app: *app
+    spec:
+      terminationGracePeriodSeconds: 1200
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: *app
+            topologyKey: kubernetes.io/hostname
+      containers:
+        - name: prometheus
+          image: prometheus
+          args:
+            - --log.level=warn
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            # populated from env, required for consumers of this base
+            - --storage.tsdb.retention.time=$(PROM_RETENTION_TIME)
+            - --web.enable-remote-write-receiver
+            - --enable-feature=exemplar-storage
+          resources:
+            requests:
+              cpu: 1
+              memory: 500Mi
+            limits:
+              cpu: 3
+              memory: 2Gi
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /-/ready
+              port: web
+              scheme: HTTP
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /-/healthy
+              port: web
+              scheme: HTTP
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - name: web
+              containerPort: 9090
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus
+            - name: datadir
+              mountPath: /prometheus
+      securityContext:
+        runAsUser: 0
+      volumes:
+        - name: config-volume
+          configMap:
+            defaultMode: 420
+            name: prometheus
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app: *app
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi


### PR DESCRIPTION
This backend is Prometheus, this is to:

* keep the pieces of our Tempo setup defined in one place
* avoid duplicate manifests across environments (just inherit from this
  one)

This is just a copy of the manifest currently running on one of our
environments with a single change: the `storage.tsdb.retention.time` is
populated from an env var (docs[1]), rather than directly in the args.
This is because this var changes across envs and we can easily patch
environment variables but not specific arguments

Some files were also renamed and certain entities extracted to their own
file

[1] https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#use-environment-variables-to-define-arguments