### PR TITLE
Fix CPU throttling on collector during high traffic

### DIFF
--- a/otel-collector/deployment.yaml
+++ b/otel-collector/deployment.yaml
@@ -39,11 +39,19 @@ spec:
           image: otel/opentelemetry-collector-contrib:0.107.0
           args:
             - "--config=/conf/otel-collector.yaml"
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: *app
+                  resource: limits.cpu
           resources:
             requests:
               cpu: 500m
               memory: 2Gi
             limits:
+              # Note: used by GOMAXPROCS in env, which will round up
+              # e.g. '1500m' -> '2'
               cpu: 1
               memory: 3Gi
           readinessProbe:


### PR DESCRIPTION
By setting `GOMAXPROCS` to the number of available CPUs available to the pod via the 'downward API'[1]. This is based on[2], otherwise the collector will use `runtime.NumCPU` (i.e. number of processors available to the _node_) when setting up batch processing.

Some experimentation: I modified our pubsub producer to start producing _lots_ of messages (and hence events) to stress test the collector, before this change, once the collector queue was full it seemed like nothing, even adding a bunch more pods, would resolve the issue, here is the rate of span production:

![span_rate](https://github.com/user-attachments/assets/a9373130-6b9e-46c3-8ab0-982f373b9dc2)

Which quickly filled up the collector queue:

![collector](https://github.com/user-attachments/assets/aaf2e2d8-934e-48ed-af3d-4152d2864ab0)

However, even if I added a bunch more pods they would just start throttling:

![throttle](https://github.com/user-attachments/assets/a1fda4b9-bd2b-4542-9ef7-bc5b438dbc98)

Though the CPU usage never looked alarming (i.e. it never approached the limit of `2`):

![cpu](https://github.com/user-attachments/assets/e7502883-3a67-4007-a4ad-3ff1f36f606f)

With this change in place we were able to process more events with the same number of pods:

![span_rate_fix](https://github.com/user-attachments/assets/16517473-a77e-4d68-bd94-dc67c7425464)

without _any_ CPU throttling, though the queue did still build up, but I expect this could be resolved by adjusting our `HorizontalPodAutoscaler`

For comparison, here's CPU usage with the fix:

![cpu_fix](https://github.com/user-attachments/assets/c31d1b9a-29bb-41ec-bad0-11e0956f812e)

[1] https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-resourceFieldRef
[2] https://github.com/open-telemetry/opentelemetry-collector/issues/4459#issuecomment-1490096473