### PR TITLE
Collector: set `GOMEMLIMIT` via k8s downward API

### DIFF
--- a/otel-collector/deployment.yaml
+++ b/otel-collector/deployment.yaml
@@ -45,6 +45,11 @@ spec:
                 resourceFieldRef:
                   containerName: *app
                   resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: *app
+                  resource: limits.memory
           resources:
             requests:
               cpu: 500m

--- a/otel-web-collector/deployment.yaml
+++ b/otel-web-collector/deployment.yaml
@@ -41,7 +41,10 @@ spec:
             - "--config=/conf/otel-collector.yaml"
           env:
             - name: GOMEMLIMIT
-              value: "200MiB"
+              valueFrom:
+                resourceFieldRef:
+                  containerName: *app
+                  resource: limits.memory
           resources:
             requests:
               cpu: 0


### PR DESCRIPTION
Rather than manually tracking this (see downward API docs[1]).

This brings the advantage of the `GOMEMLIMIT` and allocated resources not falling out of sync, e.g.[2] bumped the memory limits but not `GOMEMLIMIT` (an easy oversight to make). It comes at the cost of making `GOMEMLIMIT` equal to the amount of memory available (and not say, 90% of available memory), this _could_ cause issues as there can be other memory usages that the Go runtime/GC is not aware of (e.g. bits allocated by underlying C libraries, any memory held by the kernel) so things could still OOM.

I think we can just deploy this change and see if we actually see any negative side-effects from this trade-off. If we do see issues, another approach could be to set `requests.memory` to e.g. 90% of `limits.memory` and set `GOMEMLIMIT` off the requests value instead. There's also an open k8s issue to allow setting fractional values that would resolve this issue[3]

[1] https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-resourceFieldRef
[2] https://github.com/utilitywarehouse/kubernetes-manifests/commit/ceb1f126b6be507a146bbf4df2534bd65c98613e
[3] https://github.com/kubernetes/kubernetes/issues/91514