### PR TITLE
Update output for collector-web in diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ flowchart LR
 
         PodAWS[Pod] ---> CollectorAWS
         CollectorAWS --> KafkaAWS
-        CollectorAWSWeb --> KafkaAWS
+        CollectorAWSWeb --> CollectorAWS
         KafkaAWS --> Tempo
     end aws
 


### PR DESCRIPTION
The `collector-web` outputs to the `collector` in AWS, not directly to Kafka