### PR TITLE
Reduce 429 errors from multiple in-flight searches

### DIFF
--- a/tempo/base/config.yaml
+++ b/tempo/base/config.yaml
@@ -51,6 +51,8 @@ metrics_generator:
 # https://grafana.com/docs/tempo/latest/configuration/#query-frontend
 query_frontend:
   max_batch_size: 8
+  # Keep aligned with `search.concurrent_jobs` else search results will trigger 429 errors
+  max_outstanding_per_tenant: 10_000
   search:
     default_result_limit: 20
     max_result_limit: 500


### PR DESCRIPTION
Often when I'm opening a few tabs from clicking on search results, some will fail with a 429 error. According to the docs, this is expected more often than we'd realised after upping `concurrent_jobs` to scale querying in a previous PR.

From the docs:
When increasing concurrent_jobs, also increase the queue size per tenant, or search requests will be cause 429 errors. This is the total number of jobs per tenant allowed in the queue.