### PR TITLE
Prom v2.54.1 to align with Infra

### DIFF
--- a/tempo/base/metrics-backend/kustomization.yaml
+++ b/tempo/base/metrics-backend/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: prometheus
     newName: prom/prometheus
-    newTag: v2.53.2
+    newTag: v2.54.1


### PR DESCRIPTION
As pointed out by @matthewhughes-uw:
https://github.com/utilitywarehouse/opentelemetry-manifests/pull/50#pullrequestreview-2339324128

Align with Infra:
https://github.com/utilitywarehouse/thanos-manifests/blob/6b31fa1a457998b25565d1c85acac42ac068626e/base/prometheus/kustomization.yaml#L8C13-L8C20